### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -27,8 +27,8 @@ def chat():
         response = result.stdout.strip()
         logging.debug(f"Ollama response: {response}")
     except subprocess.CalledProcessError as e:
-        response = f"An error occurred: {e}"
-        logging.error(response)
+        logging.error(f"An error occurred: {e}")
+        response = "An internal error has occurred. Please try again later."
 
     return jsonify({"response": response})
 


### PR DESCRIPTION
Potential fix for [https://github.com/texasmadecode/CISD-self_hosted_ai-/security/code-scanning/6](https://github.com/texasmadecode/CISD-self_hosted_ai-/security/code-scanning/6)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic message.

- Modify the exception handling block in the `/chat` route to log the detailed error message and return a generic error message to the user.
- Ensure that the logging configuration is already set up to capture the detailed error information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
